### PR TITLE
Check if navigator.mimeTypes is defined

### DIFF
--- a/src/javascript/jplayer/jquery.jplayer.js
+++ b/src/javascript/jplayer/jquery.jplayer.js
@@ -3330,7 +3330,7 @@
 					}
 				} catch(e) {}
 			}
-			else if(navigator.plugins && navigator.mimeTypes.length > 0) {
+			else if(navigator.plugins && navigator.mimeTypes && navigator.mimeTypes.length > 0) {
 				flash = navigator.plugins["Shockwave Flash"];
 				if(flash) {
 					version = navigator.plugins["Shockwave Flash"].description.replace(/.*\s(\d+\.\d+).*/, "$1");


### PR DESCRIPTION
When using the player in a WebView in a Windows 8.1 App, I'm getting an error when trying to access `navigator.mimeTypes.length` because `mimeTypes` property is not defined. This should solve the issue.