### PR TITLE
Fix IE8 bug when playlist play video first time

### DIFF
--- a/src/javascript/jplayer/jquery.jplayer.js
+++ b/src/javascript/jplayer/jquery.jplayer.js
@@ -3289,7 +3289,7 @@
 			if(this.status.waitForPlay) {
 				this.status.waitForPlay = false;
 				if(this.css.jq.videoPlay.length) {
-					this.css.jq.videoPlay.hide();
+					this.css.jq.videoPlay.hide().next().css({zoom:1});
 				}
 				if(this.status.video) {
 					this.internal.poster.jq.hide();


### PR DESCRIPTION
When I use playlist,I click the start button to play a video.The jp-interface div will shift down.

![image](https://cloud.githubusercontent.com/assets/4965664/8594195/37f49560-2671-11e5-9f01-cf075e829a2a.png)
